### PR TITLE
Change $remote_addr to $proxy_add_x_forwarded_for

### DIFF
--- a/nginx_azuracast.conf
+++ b/nginx_azuracast.conf
@@ -73,8 +73,8 @@ server {
 
         proxy_set_header Host localhost:$1;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Real-IP $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         proxy_pass http://stations:$1/$3;
     }


### PR DESCRIPTION
Fix proxying issue with $remote_addr.

If you need more secure way, add `set_real_ip_from 172.18.0.1/32` to nginx server config where the ip is the docker host machine.

Thanks